### PR TITLE
Account for floating-point inaccuracies

### DIFF
--- a/source/states/PlayState.hx
+++ b/source/states/PlayState.hx
@@ -1348,7 +1348,7 @@ class PlayState extends MusicBeatState
 					// CLEAR ANY POSSIBLE GHOST NOTES
 					for (evilNote in unspawnNotes) {
 						var matches: Bool = (noteColumn == evilNote.noteData && gottaHitNote == evilNote.mustPress && evilNote.noteType == noteType);
-						if (matches && Math.abs(spawnTime - evilNote.strumTime) == 0.0) {
+						if (matches && Math.abs(spawnTime - evilNote.strumTime) < flixel.math.FlxMath.EPSILON) {
 							if (evilNote.tail.length > 0)
 								for (tail in evilNote.tail)
 								{

--- a/source/states/editors/content/EditorPlayState.hx
+++ b/source/states/editors/content/EditorPlayState.hx
@@ -346,7 +346,7 @@ class EditorPlayState extends MusicBeatSubstate
 				// CLEAR ANY POSSIBLE GHOST NOTES
 				for (evilNote in unspawnNotes) {
 					var matches: Bool = note.noteData == evilNote.noteData && note.mustPress == evilNote.mustPress && note.noteType == evilNote.noteType;
-					if (matches && Math.abs(note.strumTime - evilNote.strumTime) == 0.0) {
+					if (matches && Math.abs(note.strumTime - evilNote.strumTime) < flixel.math.FlxMath.EPSILON) {
 						if (evilNote.tail.length > 0)
 							for (tail in evilNote.tail)
 							{


### PR DESCRIPTION
this ensures notes actually do get deleted even if there's a floating-point inaccuracy, something I wish i had done originally if i knew